### PR TITLE
Fix Python ODBC Errors

### DIFF
--- a/card_automation_server/plugins/types.py
+++ b/card_automation_server/plugins/types.py
@@ -1,7 +1,6 @@
 import enum
 from dataclasses import dataclass
 from datetime import datetime
-from enum import Enum
 from typing import Optional, Literal
 
 

--- a/card_automation_server/windsx/db/engine_factory.py
+++ b/card_automation_server/windsx/db/engine_factory.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from sqlalchemy import Engine, create_engine, URL, StaticPool
+from sqlalchemy import Engine, create_engine, URL, StaticPool, NullPool
 
 
 class EngineFactory:
@@ -30,4 +30,4 @@ class EngineFactory:
             "access+pyodbc",
             query={"odbc_connect": connection_string}
         )
-        return create_engine(connection_url)
+        return create_engine(connection_url, poolclass=NullPool)

--- a/card_automation_server/windsx/lookup/access_card.py
+++ b/card_automation_server/windsx/lookup/access_card.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 
 from card_automation_server.windsx.db.models import CARDS, LOC, AclGrpName, AclGrpCombo, AclGrp, DGRP, ACL, LocCards
 from card_automation_server.windsx.lookup.acl_group_combo import AclGroupComboSet
-from card_automation_server.windsx.lookup.person import Person
+from card_automation_server.windsx.lookup.person import Person, PersonLookup
 from card_automation_server.windsx.lookup.utils import LookupInfo, DbModel
 
 
@@ -55,6 +55,7 @@ class AccessCard(DbModel):
         self._card_id: int = card_id
         self._card_number: Optional[int] = None
         self._name_id: Optional[int] = None
+        self._person: Optional[Person] = None
         self._active: Optional[bool] = None
         self._acl_group_combo: AclGroupComboSet = AclGroupComboSet(self._lookup_info, 0)
         super().__init__()
@@ -77,14 +78,21 @@ class AccessCard(DbModel):
 
     @property
     def person(self) -> Person:
-        return Person(self._lookup_info, self._name_id)
+        if self._person is None:
+            if self._name_id is None:
+                self._person = PersonLookup(self._lookup_info).new()
+            else:
+                self._person = PersonLookup(self._lookup_info).by_id(self._name_id)
+        return self._person
 
     @person.setter
     def person(self, value: Union[Person, int]):
         if isinstance(value, Person):
-            value = value.id
-
-        self._name_id = value
+            self._person = value
+            self._name_id = value.id
+        else:
+            self._person = None
+            self._name_id = value
 
     @property
     def access(self) -> frozenset[str]:
@@ -117,7 +125,7 @@ class AccessCard(DbModel):
         if self._card_id == 0:
             # Card number isn't set here as the only reason to look up a card id of 0 is to make a new card. We want to
             # let the consumer of this API set the card number, so we don't set it here.
-            self._name_id = 0
+            self._name_id = None
             self._active = False
             self._in_db = False
             return
@@ -127,7 +135,7 @@ class AccessCard(DbModel):
         if card is None:
             # We shouldn't see this unless someone directly made an access card using a card id directly. Possible, but
             # not the advised route. Still, it doesn't hurt to explicitly protect from this mistake.
-            self._name_id = 0
+            self._name_id = None
             self._active = False
             self._in_db = False
             return
@@ -139,7 +147,7 @@ class AccessCard(DbModel):
         self._in_db = True
 
     def write(self):
-        if self._name_id == 0:
+        if self._name_id is None:
             raise InvalidPersonForAccessCard("The person must be set for an access card")
 
         if not self.person.in_db:

--- a/card_automation_server/windsx/lookup/access_card.py
+++ b/card_automation_server/windsx/lookup/access_card.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+import abc
+from dataclasses import dataclass
 from datetime import datetime, date
 from typing import Optional, Union, Callable, Any
 
@@ -7,7 +11,15 @@ from sqlalchemy.orm import Session
 from card_automation_server.windsx.db.models import CARDS, LOC, AclGrpName, AclGrpCombo, AclGrp, DGRP, ACL, LocCards
 from card_automation_server.windsx.lookup.acl_group_combo import AclGroupComboSet, AclGroupComboLookup
 from card_automation_server.windsx.lookup.person import Person, PersonLookup
-from card_automation_server.windsx.lookup.utils import LookupInfo, DbModel
+from card_automation_server.windsx.lookup.utils import LookupInfo
+
+
+@dataclass(frozen=True)
+class LocCardUpdate:
+    id: int
+    card_id: int
+    loc: int
+    dl_flag: int
 
 
 class InvalidPersonForAccessCard(Exception):
@@ -19,53 +31,107 @@ class AccessCardLookup:
                  lookup_info: LookupInfo):
         self._lookup_info: LookupInfo = lookup_info
 
-    def by_card_number(self, card_number: Union[int, str]):
-        session = Session(self._lookup_info.acs_engine)
-
+    def by_card_number(self, card_number: Union[int, str]) -> 'AccessCard':
         # The DB engine might do this for us, but just to be on the safe side, we convert it to an integer with leading
         # 0's removed.
         if isinstance(card_number, str):
             card_number = card_number.lstrip('0')
 
-        valid_cards = session.scalars(
-            select(CARDS)
-            .where(CARDS.Code == card_number)
-            .where(CARDS.LocGrp == self._lookup_info.location_group_id)
-        ).all()
+        with self._lookup_info.new_session() as session:
+            card: Optional[CARDS] = session.scalar(
+                select(CARDS)
+                .where(CARDS.Code == card_number)
+                .where(CARDS.LocGrp == self._lookup_info.location_group_id)
+            )
 
-        if len(valid_cards) == 0:
-            access_card = AccessCard(self._lookup_info, 0)
+        if card is None:
+            access_card = _new_access_card(self._lookup_info)
             access_card.card_number = card_number
             return access_card
 
-        card: CARDS = valid_cards[0]
-        return AccessCard(self._lookup_info, card.ID)
+        acl_group_combo = AclGroupComboLookup(self._lookup_info).by_id(card.AclGrpComboID)
+        return _existing_access_card(self._lookup_info, card.ID, int(card.Code), card.NameID, card.Status, acl_group_combo)
+
+    def by_id(self, card_id: int) -> 'AccessCard':
+        with self._lookup_info.new_session() as session:
+            card: Optional[CARDS] = session.scalar(
+                select(CARDS)
+                .where(CARDS.ID == card_id)
+                .where(CARDS.LocGrp == self._lookup_info.location_group_id)
+            )
+
+        if card is None:
+            return _new_access_card(self._lookup_info)
+
+        acl_group_combo = AclGroupComboLookup(self._lookup_info).by_id(card.AclGrpComboID)
+        return _existing_access_card(self._lookup_info, card.ID, int(card.Code), card.NameID, card.Status, acl_group_combo)
 
 
-class AccessCard(DbModel):
+class AccessCard(abc.ABC):
     active_stop_date = datetime(year=9999, month=12, day=31)  # If we're setting a card to active, this is the stop date
 
+    @property
+    @abc.abstractmethod
+    def in_db(self) -> bool: ...
+
+    @property
+    @abc.abstractmethod
+    def id(self) -> Optional[int]: ...
+
+    @property
+    @abc.abstractmethod
+    def card_number(self) -> Optional[int]: ...
+
+    @property
+    @abc.abstractmethod
+    def active(self) -> bool: ...
+
+    @property
+    @abc.abstractmethod
+    def person(self) -> Person: ...
+
+    @property
+    @abc.abstractmethod
+    def access(self) -> frozenset[str]: ...
+
+    @abc.abstractmethod
+    def with_access(self, *names) -> 'AccessCard': ...
+
+    @abc.abstractmethod
+    def without_access(self, *names) -> 'AccessCard': ...
+
+    @abc.abstractmethod
+    def write(self): ...
+
+
+class _AccessCard(AccessCard):
     def __init__(self,
                  lookup_info: LookupInfo,
-                 card_id: int
+                 card_id: Optional[int] = None,
+                 card_number: Optional[int] = None,
+                 name_id: Optional[int] = None,
+                 active: bool = False,
+                 acl_group_combo: Optional[AclGroupComboSet] = None,
                  ):
         self._lookup_info: LookupInfo = lookup_info
         self._location_group_id: int = self._lookup_info.location_group_id
-        self._session = Session(self._lookup_info.acs_engine)
-        self._card_id: int = card_id
-        self._card_number: Optional[int] = None
-        self._name_id: Optional[int] = None
+        self._card_id: Optional[int] = card_id
+        self._card_number: Optional[int] = card_number
+        self._name_id: Optional[int] = name_id
         self._person: Optional[Person] = None
-        self._active: Optional[bool] = None
-        self._acl_group_combo: AclGroupComboSet = AclGroupComboLookup(self._lookup_info).empty()
-        super().__init__()
+        self._active: bool = active
+        self._acl_group_combo: AclGroupComboSet = acl_group_combo if acl_group_combo is not None else AclGroupComboLookup(lookup_info).empty()
 
     @property
-    def id(self) -> int:
+    def in_db(self) -> bool:
+        return self._card_id is not None
+
+    @property
+    def id(self) -> Optional[int]:
         return self._card_id
 
     @property
-    def card_number(self) -> int:
+    def card_number(self) -> Optional[int]:
         return self._card_number
 
     @card_number.setter
@@ -114,38 +180,6 @@ class AccessCard(DbModel):
 
         return self
 
-    def _get_card_from_db(self) -> Optional[CARDS]:
-        return self._session.scalar(
-            select(CARDS)
-            .where(CARDS.ID == self._card_id)
-            .where(CARDS.LocGrp == self._location_group_id)
-        )
-
-    def _populate_from_db(self):
-        if self._card_id == 0:
-            # Card number isn't set here as the only reason to look up a card id of 0 is to make a new card. We want to
-            # let the consumer of this API set the card number, so we don't set it here.
-            self._name_id = None
-            self._active = False
-            self._in_db = False
-            return
-
-        card: CARDS = self._get_card_from_db()
-
-        if card is None:
-            # We shouldn't see this unless someone directly made an access card using a card id directly. Possible, but
-            # not the advised route. Still, it doesn't hurt to explicitly protect from this mistake.
-            self._name_id = None
-            self._active = False
-            self._in_db = False
-            return
-
-        self._card_number = int(card.Code)
-        self._name_id = card.NameID
-        self._active = card.Status
-        self._acl_group_combo = AclGroupComboLookup(self._lookup_info).by_id(card.AclGrpComboID)
-        self._in_db = True
-
     def write(self):
         if self._name_id is None:
             raise InvalidPersonForAccessCard("The person must be set for an access card")
@@ -157,36 +191,44 @@ class AccessCard(DbModel):
 
         today = datetime.combine(date.today(), datetime.min.time())
 
-        card: CARDS = self._get_card_from_db()
-        if card is None:
-            card = CARDS(
-                LocGrp=self._location_group_id,
-                Code=self._card_number,
-                CardNum=str(self._card_number),
-                StartDate=today,
+        with self._lookup_info.new_session() as session:
+            card: Optional[CARDS] = None
+            if self._card_id is not None:
+                card = session.scalar(
+                    select(CARDS)
+                    .where(CARDS.ID == self._card_id)
+                    .where(CARDS.LocGrp == self._location_group_id)
+                )
+
+            if card is None:
+                card = CARDS(
+                    LocGrp=self._location_group_id,
+                    Code=self._card_number,
+                    CardNum=str(self._card_number),
+                    StartDate=today,
+                )
+
+            card.NameID = self._name_id
+            card.AclGrpComboID = self._acl_group_combo.id
+            is_active: bool = len(self._acl_group_combo.names) > 0
+            card.Status = is_active
+
+            card.StopDate = AccessCard.active_stop_date if is_active else today
+
+            session.add(card)
+            session.commit()
+            # noinspection PyTypeChecker
+            self._card_id = card.ID
+
+            # Creating this object does everything we need it to.
+            _AccessControlListUpdater(
+                self._location_group_id,
+                self._card_id,
+                self._acl_group_combo.id,
+                session,
+                self._lookup_info.updated_callback
             )
 
-        card.NameID = self._name_id
-        card.AclGrpComboID = self._acl_group_combo.id
-        is_active: bool = len(self._acl_group_combo.names) > 0
-        card.Status = is_active
-
-        card.StopDate = AccessCard.active_stop_date if is_active else today
-
-        self._session.add(card)
-        self._session.commit()
-        self._card_id = card.ID
-
-        # Creating this object does everything we need it to.
-        _AccessControlListUpdater(
-            self._location_group_id,
-            self._card_id,
-            self._acl_group_combo.id,
-            self._session,
-            self._lookup_info.updated_callback
-        )
-
-        self._in_db = True
         self._lookup_info.updated_callback(self)
 
 
@@ -467,6 +509,27 @@ class _AccessControlListUpdater:
         loc_cards.CkSum = 0
 
         self._session.add(loc_cards)
-        self._session.commit()
+        self._session.flush()
 
-        self._update_callback(loc_cards)
+        update = LocCardUpdate(
+            id=loc_cards.ID,
+            card_id=loc_cards.CardID,
+            loc=loc_cards.Loc,
+            dl_flag=loc_cards.DlFlag,
+        )
+
+        self._session.commit()
+        self._update_callback(update)
+
+
+def _new_access_card(lookup_info: LookupInfo) -> AccessCard:
+    return _AccessCard(lookup_info)
+
+
+def _existing_access_card(lookup_info: LookupInfo,
+                          card_id: int,
+                          card_number: int,
+                          name_id: Optional[int],
+                          active: bool,
+                          acl_group_combo: AclGroupComboSet) -> AccessCard:
+    return _AccessCard(lookup_info, card_id, card_number, name_id, active, acl_group_combo)

--- a/card_automation_server/windsx/lookup/access_card.py
+++ b/card_automation_server/windsx/lookup/access_card.py
@@ -5,7 +5,7 @@ from sqlalchemy import select, func
 from sqlalchemy.orm import Session
 
 from card_automation_server.windsx.db.models import CARDS, LOC, AclGrpName, AclGrpCombo, AclGrp, DGRP, ACL, LocCards
-from card_automation_server.windsx.lookup.acl_group_combo import AclGroupComboSet
+from card_automation_server.windsx.lookup.acl_group_combo import AclGroupComboSet, AclGroupComboLookup
 from card_automation_server.windsx.lookup.person import Person, PersonLookup
 from card_automation_server.windsx.lookup.utils import LookupInfo, DbModel
 
@@ -57,7 +57,7 @@ class AccessCard(DbModel):
         self._name_id: Optional[int] = None
         self._person: Optional[Person] = None
         self._active: Optional[bool] = None
-        self._acl_group_combo: AclGroupComboSet = AclGroupComboSet(self._lookup_info, 0)
+        self._acl_group_combo: AclGroupComboSet = AclGroupComboLookup(self._lookup_info).empty()
         super().__init__()
 
     @property
@@ -143,7 +143,7 @@ class AccessCard(DbModel):
         self._card_number = int(card.Code)
         self._name_id = card.NameID
         self._active = card.Status
-        self._acl_group_combo = AclGroupComboSet(self._lookup_info, card.AclGrpComboID)
+        self._acl_group_combo = AclGroupComboLookup(self._lookup_info).by_id(card.AclGrpComboID)
         self._in_db = True
 
     def write(self):

--- a/card_automation_server/windsx/lookup/access_card.py
+++ b/card_automation_server/windsx/lookup/access_card.py
@@ -31,7 +31,12 @@ class AccessCardLookup:
                  lookup_info: LookupInfo):
         self._lookup_info: LookupInfo = lookup_info
 
-    def by_card_number(self, card_number: Union[int, str]) -> 'AccessCard':
+    def new(self, card_number: Optional[Union[int, str]] = None) -> 'AccessCard':
+        if isinstance(card_number, str):
+            card_number = card_number.lstrip('0')
+        return _AccessCard(self._lookup_info, card_number=card_number)
+
+    def by_card_number(self, card_number: Union[int, str]) -> Optional['AccessCard']:
         # The DB engine might do this for us, but just to be on the safe side, we convert it to an integer with leading
         # 0's removed.
         if isinstance(card_number, str):
@@ -45,14 +50,13 @@ class AccessCardLookup:
             )
 
         if card is None:
-            access_card = _new_access_card(self._lookup_info)
-            access_card.card_number = card_number
-            return access_card
+            return None
 
-        acl_group_combo = AclGroupComboLookup(self._lookup_info).by_id(card.AclGrpComboID)
-        return _existing_access_card(self._lookup_info, card.ID, int(card.Code), card.NameID, card.Status, acl_group_combo)
+        combo_lookup = AclGroupComboLookup(self._lookup_info)
+        acl_group_combo = combo_lookup.by_id(card.AclGrpComboID) or combo_lookup.empty()
+        return _AccessCard(self._lookup_info, card.ID, int(card.Code), card.NameID, card.Status, acl_group_combo)
 
-    def by_id(self, card_id: int) -> 'AccessCard':
+    def by_id(self, card_id: int) -> Optional['AccessCard']:
         with self._lookup_info.new_session() as session:
             card: Optional[CARDS] = session.scalar(
                 select(CARDS)
@@ -61,10 +65,11 @@ class AccessCardLookup:
             )
 
         if card is None:
-            return _new_access_card(self._lookup_info)
+            return None
 
-        acl_group_combo = AclGroupComboLookup(self._lookup_info).by_id(card.AclGrpComboID)
-        return _existing_access_card(self._lookup_info, card.ID, int(card.Code), card.NameID, card.Status, acl_group_combo)
+        combo_lookup = AclGroupComboLookup(self._lookup_info)
+        acl_group_combo = combo_lookup.by_id(card.AclGrpComboID) or combo_lookup.empty()
+        return _AccessCard(self._lookup_info, card.ID, int(card.Code), card.NameID, card.Status, acl_group_combo)
 
 
 class AccessCard(abc.ABC):
@@ -88,7 +93,7 @@ class AccessCard(abc.ABC):
 
     @property
     @abc.abstractmethod
-    def person(self) -> Person: ...
+    def person(self) -> Optional[Person]: ...
 
     @property
     @abc.abstractmethod
@@ -143,12 +148,9 @@ class _AccessCard(AccessCard):
         return self._active
 
     @property
-    def person(self) -> Person:
-        if self._person is None:
-            if self._name_id is None:
-                self._person = PersonLookup(self._lookup_info).new()
-            else:
-                self._person = PersonLookup(self._lookup_info).by_id(self._name_id)
+    def person(self) -> Optional[Person]:
+        if self._person is None and self._name_id is not None:
+            self._person = PersonLookup(self._lookup_info).by_id(self._name_id)
         return self._person
 
     @person.setter
@@ -181,7 +183,7 @@ class _AccessCard(AccessCard):
         return self
 
     def write(self):
-        if self._name_id is None:
+        if self.person is None:
             raise InvalidPersonForAccessCard("The person must be set for an access card")
 
         if not self.person.in_db:
@@ -522,14 +524,3 @@ class _AccessControlListUpdater:
         self._update_callback(update)
 
 
-def _new_access_card(lookup_info: LookupInfo) -> AccessCard:
-    return _AccessCard(lookup_info)
-
-
-def _existing_access_card(lookup_info: LookupInfo,
-                          card_id: int,
-                          card_number: int,
-                          name_id: Optional[int],
-                          active: bool,
-                          acl_group_combo: AclGroupComboSet) -> AccessCard:
-    return _AccessCard(lookup_info, card_id, card_number, name_id, active, acl_group_combo)

--- a/card_automation_server/windsx/lookup/access_card.py
+++ b/card_automation_server/windsx/lookup/access_card.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import abc
 from dataclasses import dataclass
 from datetime import datetime, date
 from typing import Optional, Union, Callable, Any
@@ -72,52 +71,10 @@ class AccessCardLookup:
         return _AccessCard(self._lookup_info, card.ID, int(card.Code), card.NameID, card.Status, acl_group_combo)
 
 
-class AccessCard(abc.ABC):
-    active_stop_date = datetime(year=9999, month=12, day=31)  # If we're setting a card to active, this is the stop date
-
-    @property
-    @abc.abstractmethod
-    def in_db(self) -> bool: ...
-
-    @property
-    @abc.abstractmethod
-    def id(self) -> Optional[int]: ...
-
-    @property
-    @abc.abstractmethod
-    def card_number(self) -> Optional[int]: ...
-
-    @card_number.setter
-    @abc.abstractmethod
-    def card_number(self, value: Union[str, int]) -> None: ...
-
-    @property
-    @abc.abstractmethod
-    def active(self) -> bool: ...
-
-    @property
-    @abc.abstractmethod
-    def person(self) -> Optional[Person]: ...
-
-    @person.setter
-    @abc.abstractmethod
-    def person(self, value: Union[Person, int]) -> None: ...
-
-    @property
-    @abc.abstractmethod
-    def access(self) -> frozenset[str]: ...
-
-    @abc.abstractmethod
-    def with_access(self, *names) -> 'AccessCard': ...
-
-    @abc.abstractmethod
-    def without_access(self, *names) -> 'AccessCard': ...
-
-    @abc.abstractmethod
-    def write(self): ...
+ACTIVE_STOP_DATE = datetime(year=9999, month=12, day=31)  # If we're setting a card to active, this is the stop date
 
 
-class _AccessCard(AccessCard):
+class _AccessCard:
     def __init__(self,
                  lookup_info: LookupInfo,
                  card_id: Optional[int] = None,
@@ -163,12 +120,12 @@ class _AccessCard(AccessCard):
 
     @person.setter
     def person(self, value: Union[Person, int]):
-        if isinstance(value, Person):
-            self._person = value
-            self._name_id = value.id
-        else:
+        if isinstance(value, int):
             self._person = None
             self._name_id = value
+        else:
+            self._person = value
+            self._name_id = value.id
 
     @property
     def access(self) -> frozenset[str]:
@@ -223,7 +180,7 @@ class _AccessCard(AccessCard):
             is_active: bool = len(self._acl_group_combo.names) > 0
             card.Status = is_active
 
-            card.StopDate = AccessCard.active_stop_date if is_active else today
+            card.StopDate = ACTIVE_STOP_DATE if is_active else today
 
             session.add(card)
             session.commit()
@@ -240,6 +197,13 @@ class _AccessCard(AccessCard):
             )
 
         self._lookup_info.updated_callback(self)
+
+
+class _Unused:
+    pass
+
+
+AccessCard = Union[_AccessCard, _Unused]
 
 
 class _AccessControlListUpdater:

--- a/card_automation_server/windsx/lookup/access_card.py
+++ b/card_automation_server/windsx/lookup/access_card.py
@@ -87,6 +87,10 @@ class AccessCard(abc.ABC):
     @abc.abstractmethod
     def card_number(self) -> Optional[int]: ...
 
+    @card_number.setter
+    @abc.abstractmethod
+    def card_number(self, value: Union[str, int]) -> None: ...
+
     @property
     @abc.abstractmethod
     def active(self) -> bool: ...
@@ -94,6 +98,10 @@ class AccessCard(abc.ABC):
     @property
     @abc.abstractmethod
     def person(self) -> Optional[Person]: ...
+
+    @person.setter
+    @abc.abstractmethod
+    def person(self, value: Union[Person, int]) -> None: ...
 
     @property
     @abc.abstractmethod
@@ -513,6 +521,7 @@ class _AccessControlListUpdater:
         self._session.add(loc_cards)
         self._session.flush()
 
+        # noinspection PyTypeChecker
         update = LocCardUpdate(
             id=loc_cards.ID,
             card_id=loc_cards.CardID,

--- a/card_automation_server/windsx/lookup/acl_group_combo.py
+++ b/card_automation_server/windsx/lookup/acl_group_combo.py
@@ -64,7 +64,7 @@ class AclGroupComboSet(DbModel):
         self._location_group_id: int = self._lookup_info.location_group_id
         self._session = Session(self._lookup_info.acs_engine)
         self._combo_id = combo_id
-        self._names: Optional[frozenset[[str]]] = None
+        self._names: Optional[frozenset[str]] = None
         super().__init__()
 
     @property

--- a/card_automation_server/windsx/lookup/acl_group_combo.py
+++ b/card_automation_server/windsx/lookup/acl_group_combo.py
@@ -1,11 +1,14 @@
+from __future__ import annotations
+
+import abc
 from itertools import groupby
 from typing import Optional, Union, Iterable, Dict, Collection, List
 
-from sqlalchemy import select, distinct
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from card_automation_server.windsx.db.models import AclGrpCombo, AclGrpName
-from card_automation_server.windsx.lookup.utils import LookupInfo, DbModel
+from card_automation_server.windsx.lookup.utils import LookupInfo
 
 StringOrFrozenSet = Union[str, frozenset[str], Iterable[str]]
 
@@ -35,40 +38,81 @@ class AclGroupComboLookup:
         self._lookup_info: LookupInfo = lookup_info
 
     def empty(self) -> 'AclGroupComboSet':
-        return AclGroupComboSet(self._lookup_info, 0)
+        return _empty_combo_set(self._lookup_info)
 
     def by_names(self, *names: StringOrFrozenSet) -> 'AclGroupComboSet':
         return self.empty().with_names(*names)
 
-    def by_id(self, combo_id: int):
-        return AclGroupComboSet(self._lookup_info, combo_id)
+    def by_id(self, combo_id: int) -> 'AclGroupComboSet':
+        with self._lookup_info.new_session() as session:
+            rows = session.execute(
+                select(AclGrpName.Name)
+                .join(AclGrpCombo, AclGrpCombo.AclGrpNameID == AclGrpName.ID)
+                .where(AclGrpCombo.ComboID == combo_id)
+                .where(AclGrpCombo.LocGrp == self._lookup_info.location_group_id)
+                .where(AclGrpName.LocGrp == self._lookup_info.location_group_id)
+            ).all()
+            if not rows:
+                return _empty_combo_set(self._lookup_info)
+            names = frozenset(row.Name for row in rows)
+            return _existing_combo_set(self._lookup_info, combo_id, names)
 
     def all(self) -> List['AclGroupComboSet']:
-        session = Session(self._lookup_info.acs_engine)
-        combo_id_rows = session.execute(
-            select(distinct(AclGrpCombo.ComboID))
-            .join(AclGrpName, AclGrpName.ID == AclGrpCombo.AclGrpNameID)
-            .where(AclGrpCombo.LocGrp == self._lookup_info.location_group_id)
-            .where(AclGrpName.LocGrp == self._lookup_info.location_group_id)
-        ).all()
+        with self._lookup_info.new_session() as session:
+            rows = session.execute(
+                select(AclGrpCombo.ComboID, AclGrpName.Name)
+                .join(AclGrpName, AclGrpName.ID == AclGrpCombo.AclGrpNameID)
+                .where(AclGrpCombo.LocGrp == self._lookup_info.location_group_id)
+                .where(AclGrpName.LocGrp == self._lookup_info.location_group_id)
+            ).all()
 
-        return [self.by_id(row[0]) for row in combo_id_rows]
+            combos: Dict[int, frozenset[str]] = {}
+            for row in rows:
+                combo_id, name = row.ComboID, row.Name
+                combos[combo_id] = combos.get(combo_id, frozenset()) | {name}
+
+            return [
+                _existing_combo_set(self._lookup_info, combo_id, names)
+                for combo_id, names in combos.items()
+            ]
 
 
-class AclGroupComboSet(DbModel):
+class AclGroupComboSet(abc.ABC):
+    @property
+    @abc.abstractmethod
+    def id(self) -> Optional[int]: ...
+
+    @property
+    @abc.abstractmethod
+    def names(self) -> frozenset[str]: ...
+
+    @property
+    @abc.abstractmethod
+    def in_db(self) -> bool: ...
+
+    @abc.abstractmethod
+    def with_names(self, *names: StringOrFrozenSet) -> 'AclGroupComboSet': ...
+
+    @abc.abstractmethod
+    def without_names(self, *names: StringOrFrozenSet) -> 'AclGroupComboSet': ...
+
+    @abc.abstractmethod
+    def write(self): ...
+
+
+class _AclGroupComboSet(AclGroupComboSet):
     def __init__(self,
                  lookup_info: LookupInfo,
-                 combo_id: int
+                 combo_id: Optional[int],
+                 names: frozenset[str]
                  ):
         self._lookup_info: LookupInfo = lookup_info
         self._location_group_id: int = self._lookup_info.location_group_id
-        self._session = Session(self._lookup_info.acs_engine)
-        self._combo_id = combo_id
-        self._names: Optional[frozenset[str]] = None
-        super().__init__()
+        self._combo_id: Optional[int] = combo_id
+        self._names: frozenset[str] = names
 
     @property
-    def id(self) -> int:
+    def id(self) -> Optional[int]:
         return self._combo_id
 
     @property
@@ -77,34 +121,11 @@ class AclGroupComboSet(DbModel):
 
     @property
     def in_db(self) -> bool:
-        return self._in_db
+        return self._combo_id is not None
 
     def __str__(self):
         names = ", ".join(self.names)
         return f"{self.id}: {names}"
-
-    def _populate_from_db(self):
-        name_id_rows = self._session.execute(
-            select(AclGrpCombo.AclGrpNameID)
-            .join(AclGrpName, AclGrpName.ID == AclGrpCombo.AclGrpNameID)
-            .where(AclGrpCombo.ComboID == self._combo_id)
-            .where(AclGrpCombo.LocGrp == self._location_group_id)
-            .where(AclGrpName.LocGrp == self._location_group_id)
-        ).all()
-
-        if len(name_id_rows) == 0:
-            self._names = frozenset()
-            self._in_db = False
-            return
-
-        # We know it's in there now
-        self._in_db = True
-
-        # Let's grab our names
-        name_ids = set(row.AclGrpNameID for row in name_id_rows)
-        id_to_names = self._names_by_id(name_ids)
-
-        self._names = frozenset(id_to_names.values())
 
     @staticmethod
     def _to_set(*values: StringOrFrozenSet) -> frozenset[str]:
@@ -120,28 +141,12 @@ class AclGroupComboSet(DbModel):
 
         return result
 
-    def _names_by_id(self, name_ids: Collection[int]) -> Dict[int, str]:
-        acl_group_name_rows = self._session.execute(
-            select(AclGrpName.ID, AclGrpName.Name)
-            .where(AclGrpName.ID.in_(name_ids))
-        ).all()
-
-        id_to_names = {}
-
-        for row in acl_group_name_rows:
-            id_to_names[row[0]] = row[1]
-
-        if len(id_to_names) != len(name_ids):
-            raise Exception("Could not fetch all names by ID, suggesting DB has invalid data")
-
-        return id_to_names
-
-    def _name_ids_by_name(self, names: Collection[str]) -> Dict[str, int]:
+    def _name_ids_by_name(self, session: Session, names: Collection[str]) -> Dict[str, int]:
         if len(names) == 0:
             # Our tests would handle the below SQL statement just fine, but Microsoft Access is less happy with it.
             return {}
 
-        acl_group_name_rows = self._session.execute(
+        acl_group_name_rows = session.execute(
             select(AclGrpName.ID, AclGrpName.Name)
             .where(AclGrpName.Name.in_(names))
             .where(AclGrpName.LocGrp == self._location_group_id)
@@ -176,26 +181,23 @@ class AclGroupComboSet(DbModel):
 
         return self._get_acl_by_names(new_names)
 
-    def _get_acl_by_names(self, all_names):
-        wanted_name_ids = set(self._name_ids_by_name(all_names).values())
+    def _get_acl_by_names(self, all_names: frozenset[str]) -> 'AclGroupComboSet':
+        with self._lookup_info.new_session() as session:
+            wanted_name_ids = set(self._name_ids_by_name(session, all_names).values())
 
-        acl_combos = self._session.execute(
-            select(AclGrpCombo.AclGrpNameID, AclGrpCombo.ComboID)
-            .where(AclGrpCombo.LocGrp == self._location_group_id)
-        ).all()
-        grouped_by_combo_id = groupby(acl_combos, lambda x: x[1])  # Group by the Combo ID
+            acl_combos = session.execute(
+                select(AclGrpCombo.AclGrpNameID, AclGrpCombo.ComboID)
+                .where(AclGrpCombo.LocGrp == self._location_group_id)
+            ).all()
+            grouped_by_combo_id = groupby(acl_combos, lambda x: x[1])  # Group by the Combo ID
 
-        for new_combo_id, value in grouped_by_combo_id:
-            acl_name_ids = set([x.AclGrpNameID for x in value])
-            if acl_name_ids == wanted_name_ids:  # Oh good, we found an exact match
-                return AclGroupComboSet(self._lookup_info, new_combo_id)
+            for new_combo_id, value in grouped_by_combo_id:
+                acl_name_ids = set([x.AclGrpNameID for x in value])
+                if acl_name_ids == wanted_name_ids:  # Oh good, we found an exact match
+                    return _existing_combo_set(self._lookup_info, new_combo_id, all_names)
 
-        # This doesn't exist, so we create one, update the names manually, and mark it as not in the database
-        result = AclGroupComboSet(self._lookup_info, 0)
-        result._names = all_names
-        result._in_db = False
-
-        return result
+        # This doesn't exist, so we create one with the names but mark it as not in the database
+        return _AclGroupComboSet(self._lookup_info, None, all_names)
 
     def write(self):
         if self.in_db:
@@ -204,33 +206,41 @@ class AclGroupComboSet(DbModel):
         if len(self._names) == 0:
             return
 
-        names_to_ids = self._name_ids_by_name(self._names)
-        name_id_iterator = iter(names_to_ids.values())
+        with self._lookup_info.new_session() as session:
+            names_to_ids = self._name_ids_by_name(session, self._names)
+            name_id_iterator = iter(names_to_ids.values())
 
-        # We need to insert one of them to get a new combo id. The ID field gets a generated ID, which we treat as the
-        # combo id for this AclGrpComboId
-        starting_combo = AclGrpCombo(
-            AclGrpNameID=next(name_id_iterator),  # next meaning "just grab the first one". We handle any others below
-            ComboID=0,  # Explicitly setting this to 0, will update it after this record is inserted
-            LocGrp=self._location_group_id
-        )
-        self._session.add(starting_combo)
-        self._session.commit()
+            # We need to insert one of them to get a new combo id. The ID field gets a generated ID, which we treat as the
+            # combo id for this AclGrpComboId
+            starting_combo = AclGrpCombo(
+                AclGrpNameID=next(name_id_iterator),  # next meaning "just grab the first one". We handle any others below
+                ComboID=0,  # Explicitly setting this to 0, will update it after this record is inserted
+                LocGrp=self._location_group_id
+            )
+            session.add(starting_combo)
+            session.commit()
 
-        # Now we should have an ID we can assign to this set and to the starting object, which will get updated next commit
-        self._combo_id = starting_combo.ComboID = starting_combo.ID
+            # Now we should have an ID we can assign to this set and to the starting object, which will get updated next commit
+            self._combo_id = starting_combo.ComboID = starting_combo.ID
 
-        self._session.add_all(
-            [
-                AclGrpCombo(
-                    AclGrpNameID=name_id,
-                    ComboID=self._combo_id,
-                    LocGrp=self._location_group_id
-                ) for name_id in name_id_iterator
-            ]
-        )
+            session.add_all(
+                [
+                    AclGrpCombo(
+                        AclGrpNameID=name_id,
+                        ComboID=self._combo_id,
+                        LocGrp=self._location_group_id
+                    ) for name_id in name_id_iterator
+                ]
+            )
 
-        self._session.commit()
+            session.commit()
 
-        self._in_db = True  # Now we're in the database :)
-        self._lookup_info.updated_callback(self)
+            self._lookup_info.updated_callback(self)
+
+
+def _empty_combo_set(lookup_info: LookupInfo) -> AclGroupComboSet:
+    return _AclGroupComboSet(lookup_info, None, frozenset())
+
+
+def _existing_combo_set(lookup_info: LookupInfo, combo_id: int, names: frozenset[str]) -> AclGroupComboSet:
+    return _AclGroupComboSet(lookup_info, combo_id, names)

--- a/card_automation_server/windsx/lookup/acl_group_combo.py
+++ b/card_automation_server/windsx/lookup/acl_group_combo.py
@@ -43,7 +43,7 @@ class AclGroupComboLookup:
     def by_names(self, *names: StringOrFrozenSet) -> 'AclGroupComboSet':
         return self.empty().with_names(*names)
 
-    def by_id(self, combo_id: int) -> 'AclGroupComboSet':
+    def by_id(self, combo_id: int) -> Optional['AclGroupComboSet']:
         with self._lookup_info.new_session() as session:
             rows = session.execute(
                 select(AclGrpName.Name)
@@ -53,7 +53,7 @@ class AclGroupComboLookup:
                 .where(AclGrpName.LocGrp == self._lookup_info.location_group_id)
             ).all()
             if not rows:
-                return _empty_combo_set(self._lookup_info)
+                return None
             names = frozenset(row.Name for row in rows)
             return _existing_combo_set(self._lookup_info, combo_id, names)
 

--- a/card_automation_server/windsx/lookup/acl_group_combo.py
+++ b/card_automation_server/windsx/lookup/acl_group_combo.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import abc
 from itertools import groupby
 from typing import Optional, Union, Iterable, Dict, Collection, List
 
@@ -77,30 +76,7 @@ class AclGroupComboLookup:
             ]
 
 
-class AclGroupComboSet(abc.ABC):
-    @property
-    @abc.abstractmethod
-    def id(self) -> Optional[int]: ...
-
-    @property
-    @abc.abstractmethod
-    def names(self) -> frozenset[str]: ...
-
-    @property
-    @abc.abstractmethod
-    def in_db(self) -> bool: ...
-
-    @abc.abstractmethod
-    def with_names(self, *names: StringOrFrozenSet) -> 'AclGroupComboSet': ...
-
-    @abc.abstractmethod
-    def without_names(self, *names: StringOrFrozenSet) -> 'AclGroupComboSet': ...
-
-    @abc.abstractmethod
-    def write(self): ...
-
-
-class _AclGroupComboSet(AclGroupComboSet):
+class _AclGroupComboSet:
     def __init__(self,
                  lookup_info: LookupInfo,
                  combo_id: Optional[int],
@@ -236,6 +212,13 @@ class _AclGroupComboSet(AclGroupComboSet):
             session.commit()
 
             self._lookup_info.updated_callback(self)
+
+
+class _Unused:
+    pass
+
+
+AclGroupComboSet = Union[_AclGroupComboSet, _Unused]
 
 
 def _empty_combo_set(lookup_info: LookupInfo) -> AclGroupComboSet:

--- a/card_automation_server/windsx/lookup/door_lookup.py
+++ b/card_automation_server/windsx/lookup/door_lookup.py
@@ -1,13 +1,11 @@
-import threading
 from datetime import timedelta
 from typing import Optional
 
 from sqlalchemy import select
-from sqlalchemy.orm import Session
 
 from card_automation_server.plugins.types import CardScan
 from card_automation_server.windsx.db.models import DEV, LOC
-from card_automation_server.windsx.lookup.utils import LookupInfo, DbModel
+from card_automation_server.windsx.lookup.utils import LookupInfo
 from card_automation_server.workers.events import DoorStateUpdate, DoorState
 
 
@@ -16,71 +14,66 @@ class DoorLookup:
                  lookup_info: LookupInfo,
                  *door_ids: int):
         self._lookup_info: LookupInfo = lookup_info
-        self._location_group_id: int = lookup_info.location_group_id
-        self._session = Session(lookup_info.acs_engine)
-        self._door_ids = list(door_ids)
-        self._lock = threading.Lock()
-
-    def all(self) -> list['Door']:
-        statement = (
+        self._base_statement = (
             select(DEV)
             .join(LOC, LOC.Loc == DEV.Loc)
-            .where(LOC.LocGrp == self._location_group_id)
+            .where(LOC.LocGrp == lookup_info.location_group_id)
         )
-        if len(self._door_ids) > 0:
-            statement = statement.where(DEV.ID.in_(self._door_ids))
 
-        with self._lock:
-            dev = self._session.scalars(statement).all()
-        return [Door(self._lookup_info, d.ID) for d in dev]
+        if door_ids:
+            self._base_statement = self._base_statement.where(DEV.ID.in_(door_ids))
+
+    def all(self) -> list['Door']:
+        with self._lookup_info.new_session() as session:
+            devs = session.scalars(self._base_statement).all()
+            return [Door(self._lookup_info, d.ID, d.Name, d.Device, d.Loc) for d in devs]
 
     def by_id(self, id_: int) -> Optional['Door']:
-        doors = [d for d in self.all() if d.id == id_]
+        statement = self._base_statement.where(DEV.ID == id_)
 
-        if len(doors) == 0:
-            return None
-
-        return doors[0]
+        with self._lookup_info.new_session() as session:
+            dev = session.scalar(statement)
+            return Door(self._lookup_info, dev.ID, dev.Name, dev.Device, dev.Loc) if dev is not None else None
 
     def by_device_info(self, location_id: int, device_id: int) -> Optional['Door']:
-        doors = [
-            d for d in self.all()
-            if d.location_id == location_id and d.device_id == device_id
-        ]
+        statement = (
+            self._base_statement
+            .where(DEV.Loc == location_id)
+            .where(DEV.Device == device_id)
+        )
 
-        if len(doors) == 0:
-            return None
-
-        return doors[0]
+        with self._lookup_info.new_session() as session:
+            dev = session.scalar(statement)
+            return Door(self._lookup_info, dev.ID, dev.Name, dev.Device, dev.Loc) if dev is not None else None
 
     def by_card_scan(self, card_scan: CardScan) -> Optional['Door']:
         statement = (
-            select(DEV)
-            .join(LOC, LOC.Loc == DEV.Loc)
-            .where(LOC.LocGrp == self._location_group_id)
+            self._base_statement
             .where(DEV.Loc == card_scan.location_id)
             .where(DEV.Device == card_scan.device)
         )
-        if len(self._door_ids) > 0:
-            statement = statement.where(DEV.ID.in_(self._door_ids))
 
-        with self._lock:
-            dev = self._session.scalar(statement)
-        return Door(self._lookup_info, dev.ID) if dev is not None else None
+        with self._lookup_info.new_session() as session:
+            dev = session.scalar(statement)
+            return Door(self._lookup_info, dev.ID, dev.Name, dev.Device, dev.Loc) if dev is not None else None
 
 
-class Door(DbModel):
+class Door:
     def __init__(self,
                  lookup_info: LookupInfo,
-                 dev_id: int):
+                 dev_id: int,
+                 name: str,
+                 device_id: int,
+                 location_id: int):
         self._lookup_info: LookupInfo = lookup_info
-        self._location_group_id: int = lookup_info.location_group_id
-        self._session = Session(lookup_info.acs_engine)
         self._id = dev_id
-        self._name: Optional[str] = None
-        self._device_id: Optional[int] = None
-        self._location_id: Optional[int] = None
-        super().__init__()
+        self._name: str = name
+        self._device_id: int = device_id
+        self._location_id: int = location_id
+
+    @property
+    def in_db(self) -> bool:
+        return True
 
     @property
     def id(self) -> int:
@@ -97,19 +90,6 @@ class Door(DbModel):
     @property
     def location_id(self) -> int:
         return self._location_id
-
-    def _populate_from_db(self):
-        dev: DEV = self._session.scalar(
-            select(DEV)
-            .join(LOC, LOC.Loc == DEV.Loc)
-            .where(LOC.LocGrp == self._location_group_id)
-            .where(DEV.ID == self._id)
-        )
-
-        self._name = dev.Name
-        self._device_id = dev.Device
-        self._location_id = dev.Loc
-        self._in_db = True
 
     def open(self, timeout: Optional[timedelta] = None):
         self._lookup_info.updated_callback(DoorStateUpdate(

--- a/card_automation_server/windsx/lookup/door_lookup.py
+++ b/card_automation_server/windsx/lookup/door_lookup.py
@@ -72,10 +72,6 @@ class Door:
         self._location_id: int = location_id
 
     @property
-    def in_db(self) -> bool:
-        return True
-
-    @property
     def id(self) -> int:
         return self._id
 

--- a/card_automation_server/windsx/lookup/person.py
+++ b/card_automation_server/windsx/lookup/person.py
@@ -246,13 +246,25 @@ class Person(abc.ABC):
     @abc.abstractmethod
     def first_name(self) -> Optional[str]: ...
 
+    @first_name.setter
+    @abc.abstractmethod
+    def first_name(self, value: str) -> None: ...
+
     @property
     @abc.abstractmethod
     def last_name(self) -> Optional[str]: ...
 
+    @last_name.setter
+    @abc.abstractmethod
+    def last_name(self, value: str) -> None: ...
+
     @property
     @abc.abstractmethod
     def company_id(self) -> Optional[int]: ...
+
+    @company_id.setter
+    @abc.abstractmethod
+    def company_id(self, value: int) -> None: ...
 
     @property
     @abc.abstractmethod

--- a/card_automation_server/windsx/lookup/person.py
+++ b/card_automation_server/windsx/lookup/person.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import abc
 import enum
 from typing import Optional, Any, Sequence, Union, Pattern
@@ -6,7 +8,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from card_automation_server.windsx.db.models import NAMES, UDF, UdfName, CARDS, UdfSel
-from card_automation_server.windsx.lookup.utils import DbModel, LookupInfo
+from card_automation_server.windsx.lookup.utils import LookupInfo
 
 
 class InvalidUdfName(Exception):
@@ -36,21 +38,35 @@ class _SearchCriteria(enum.Enum):
     COMPANY_ID = enum.auto()
 
 
+def _load_udfs(session: Session, location_group_id: int, name_ids: list[int]) -> dict[int, dict[str, str]]:
+    udf_rows = session.execute(
+        select(UdfName.Name, UDF.UdfText, UDF.NameID)
+        .join(UDF, UDF.UdfNum == UdfName.UdfNum)
+        .where(UdfName.LocGrp == location_group_id)
+        .where(UDF.LocGrp == location_group_id)
+        .where(UDF.NameID.in_(name_ids))
+    ).all()
+
+    result: dict[int, dict[str, str]] = {name_id: {} for name_id in name_ids}
+    for row in udf_rows:
+        result[row.NameID][row.Name] = row.UdfText
+    return result
+
+
 class _PersonSearchBase(abc.ABC):
     def __init__(self, lookup_info: LookupInfo):
         self._lookup_info: LookupInfo = lookup_info
         self._location_group_id: int = lookup_info.location_group_id
-        self._session = Session(lookup_info.acs_engine)
         self._criteria: dict[_SearchCriteria, Any] = {}
         self._udf_criteria: dict[str, Union[str, Pattern[str]]] = {}
 
     @abc.abstractmethod
-    def _search_object(self) -> '_PersonSearchBuilder':
+    def _search_object(self) -> _PersonSearchBuilder:
         # This method allows the same methods to be on PersonLookup and _PersonSearchBuilder while allowing them to be
         # chained like a builder pattern and ensuring the PersonLookup can be re-used to find multiple people.
         pass
 
-    def by_name(self, first_name: str, last_name: str) -> '_PersonSearchBuilder':
+    def by_name(self, first_name: str, last_name: str) -> _PersonSearchBuilder:
         search: _PersonSearchBuilder = self._search_object()
 
         search._criteria[_SearchCriteria.FIRST_NAME] = first_name
@@ -58,7 +74,7 @@ class _PersonSearchBase(abc.ABC):
 
         return search
 
-    def by_udf(self, udf_name: str, udf_text: Union[str, Pattern[str]]) -> '_PersonSearchBuilder':
+    def by_udf(self, udf_name: str, udf_text: Union[str, Pattern[str]]) -> _PersonSearchBuilder:
         search: _PersonSearchBuilder = self._search_object()
 
         if _SearchCriteria.UDF not in search._criteria:
@@ -69,22 +85,22 @@ class _PersonSearchBase(abc.ABC):
 
         return search
 
-    def by_card(self, code: int) -> '_PersonSearchBuilder':
+    def by_card(self, code: int) -> _PersonSearchBuilder:
         search: _PersonSearchBuilder = self._search_object()
 
         search._criteria[_SearchCriteria.CARD_CODE] = code
 
         return search
 
-    def by_company(self, company: int) -> '_PersonSearchBuilder':
+    def by_company(self, company: int) -> _PersonSearchBuilder:
         search: _PersonSearchBuilder = self._search_object()
 
         search._criteria[_SearchCriteria.COMPANY_ID] = company
 
         return search
 
-    def __get_udf_name_ids(self) -> set[int]:
-        udf_names_and_ids = self._session.execute(
+    def __get_udf_name_ids(self, session: Session) -> set[int]:
+        udf_names_and_ids = session.execute(
             select(UdfName.UdfNum, UdfName.Name) \
                 .where(UdfName.LocGrp == self._lookup_info.location_group_id) \
                 .where(UdfName.Name.in_(self._udf_criteria.keys()))
@@ -113,7 +129,7 @@ class _PersonSearchBase(abc.ABC):
             if isinstance(udf_text, str):
                 statement = statement.where(UDF.UdfText == udf_text)
 
-            rows = self._session.execute(statement).all()
+            rows = session.execute(statement).all()
 
             name_ids = set()
             for row in rows:
@@ -129,9 +145,8 @@ class _PersonSearchBase(abc.ABC):
 
         return name_ids_result
 
-    def find(self) -> list['Person']:
-        statement = select(NAMES.ID) \
-            .where(NAMES.LocGrp == self._location_group_id)
+    def find(self) -> list[Person]:
+        statement = select(NAMES).where(NAMES.LocGrp == self._location_group_id)
 
         criteria_key: _SearchCriteria
         for criteria_key, criteria in self._criteria.items():
@@ -139,30 +154,49 @@ class _PersonSearchBase(abc.ABC):
                 statement = statement.where(NAMES.FName == criteria)
             elif criteria_key == _SearchCriteria.LAST_NAME:
                 statement = statement.where(NAMES.LName == criteria)
-            elif criteria_key == _SearchCriteria.UDF:
-                udf_name_ids = self.__get_udf_name_ids()
-                if udf_name_ids:
-                    statement = statement.where(NAMES.ID.in_(udf_name_ids))
-                else:
-                    # We have no matching criteria, so this query would fail anyway
-                    # Access hates having an empty query in an in_ statement.
-                    return []
             elif criteria_key == _SearchCriteria.CARD_CODE:
                 statement = statement.join(CARDS, CARDS.NameID == NAMES.ID) \
                     .where(CARDS.Code == criteria) \
                     .where(CARDS.LocGrp == self._location_group_id)
             elif criteria_key == _SearchCriteria.COMPANY_ID:
                 statement = statement.where(NAMES.Company == criteria)
+            elif criteria_key == _SearchCriteria.UDF:
+                pass  # handled below with session
             else:
                 raise Exception("Unknown search criteria")
 
-        name_ids = self._session.scalars(statement).all()
+        with self._lookup_info.new_session() as session:
+            if _SearchCriteria.UDF in self._criteria:
+                udf_name_ids = self.__get_udf_name_ids(session)
+                if not udf_name_ids:
+                    # We have no matching criteria, so this query would fail anyway
+                    # Access hates having an empty query in an in_ statement.
+                    return []
+                statement = statement.where(NAMES.ID.in_(udf_name_ids))
 
-        return [Person(self._lookup_info, name_id) for name_id in name_ids]
+            names = session.scalars(statement).all()
+
+            if not names:
+                return []
+
+            name_ids = [n.ID for n in names]
+            udf_by_name_id = _load_udfs(session, self._location_group_id, name_ids)
+
+            return [
+                _existing_person(
+                    self._lookup_info,
+                    n.ID,
+                    n.FName,
+                    n.LName,
+                    n.Company,
+                    udf_by_name_id[n.ID],
+                )
+                for n in names
+            ]
 
 
 class _PersonSearchBuilder(_PersonSearchBase):
-    def _search_object(self) -> '_PersonSearchBuilder':
+    def _search_object(self) -> _PersonSearchBuilder:
         return self
 
 
@@ -170,32 +204,86 @@ class PersonLookup(_PersonSearchBase):
     def __init__(self, lookup_info: LookupInfo):
         super().__init__(lookup_info)
 
-    def _search_object(self) -> '_PersonSearchBuilder':
+    def _search_object(self) -> _PersonSearchBuilder:
         return _PersonSearchBuilder(self._lookup_info)
 
-    def new(self) -> 'Person':
-        return Person(self._lookup_info, 0)
+    def new(self) -> Person:
+        return _new_person(self._lookup_info)
 
-    def by_id(self, name_id: int) -> 'Person':
-        return Person(self._lookup_info, name_id)
+    def by_id(self, name_id: int) -> Person:
+        with self._lookup_info.new_session() as session:
+            name: Optional[NAMES] = session.scalar(
+                select(NAMES)
+                .where(NAMES.ID == name_id)
+                .where(NAMES.LocGrp == self._location_group_id)
+            )
+
+            if name is None:
+                return _new_person(self._lookup_info)
+
+            udf_data = _load_udfs(session, self._location_group_id, [name_id])
+
+            return _existing_person(
+                self._lookup_info,
+                name.ID,
+                name.FName,
+                name.LName,
+                name.Company,
+                udf_data[name_id],
+            )
 
 
-class Person(DbModel):
-    def __init__(self,
-                 lookup_info: LookupInfo,
-                 name_id: int):
-        self._lookup_info: LookupInfo = lookup_info
-        self._location_group_id: int = lookup_info.location_group_id
-        self._session = Session(lookup_info.acs_engine)
-        self._name_id: int = name_id
-        self._first_name: Optional[str] = None
-        self._last_name: Optional[str] = None
-        self._company_id: Optional[int] = None
-        self._user_defined_fields: Optional[dict[str, str]] = None
-        super().__init__()
+class Person(abc.ABC):
+    @property
+    @abc.abstractmethod
+    def in_db(self) -> bool: ...
 
     @property
-    def id(self) -> int:
+    @abc.abstractmethod
+    def id(self) -> Optional[int]: ...
+
+    @property
+    @abc.abstractmethod
+    def first_name(self) -> Optional[str]: ...
+
+    @property
+    @abc.abstractmethod
+    def last_name(self) -> Optional[str]: ...
+
+    @property
+    @abc.abstractmethod
+    def company_id(self) -> Optional[int]: ...
+
+    @property
+    @abc.abstractmethod
+    def user_defined_fields(self) -> dict[str, str]: ...
+
+    @abc.abstractmethod
+    def write(self): ...
+
+
+class _Person(Person):
+    def __init__(self,
+                 lookup_info: LookupInfo,
+                 name_id: Optional[int] = None,
+                 first_name: Optional[str] = None,
+                 last_name: Optional[str] = None,
+                 company_id: Optional[int] = None,
+                 user_defined_fields: Optional[dict[str, str]] = None):
+        self._lookup_info: LookupInfo = lookup_info
+        self._location_group_id: int = lookup_info.location_group_id
+        self._name_id: Optional[int] = name_id
+        self._first_name: Optional[str] = first_name
+        self._last_name: Optional[str] = last_name
+        self._company_id: Optional[int] = company_id
+        self._user_defined_fields: dict[str, str] = user_defined_fields if user_defined_fields is not None else {}
+
+    @property
+    def in_db(self) -> bool:
+        return self._name_id is not None
+
+    @property
+    def id(self) -> Optional[int]:
         return self._name_id
 
     @property
@@ -223,65 +311,11 @@ class Person(DbModel):
         self._company_id = value
 
     @property
-    def user_defined_fields(self) -> Optional[dict[str, str]]:
+    def user_defined_fields(self) -> dict[str, str]:
         return self._user_defined_fields
 
-    def _populate_from_db(self):
-        if self._name_id == 0:
-            self._user_defined_fields = {}
-            self._in_db = False
-            return
-
-        name: Optional[NAMES] = self._session.scalar(
-            select(NAMES)
-            .where(NAMES.ID == self._name_id)
-            .where(NAMES.LocGrp == self._location_group_id)
-        )
-
-        self._user_defined_fields = {}
-        if name is None:
-            self._in_db = False
-            return
-
-        self._first_name = name.FName
-        self._last_name = name.LName
-        self._company_id = name.Company
-
-        user_defined_fields = self._session.execute(
-            select(UdfName.Name, UDF.UdfText)
-            .join(UDF, UDF.UdfNum == UdfName.UdfNum) \
-            .where(UdfName.LocGrp == self._location_group_id) \
-            .where(UDF.LocGrp == self._location_group_id) \
-            .where(UDF.NameID == self._name_id)
-        ).all()
-
-        for udf_name, value in user_defined_fields:
-            self._user_defined_fields[udf_name] = value
-
-        self._in_db = True
-
-    def write(self):
-        name: Optional[NAMES] = self._session.scalar(
-            select(NAMES)
-            .where(NAMES.ID == self._name_id)
-            .where(NAMES.LocGrp == self._location_group_id)
-        )
-
-        if name is None:
-            name = NAMES(
-                LocGrp=self._location_group_id,
-            )
-
-        name.FName = self._first_name
-        name.LName = self._last_name
-        name.Company = self._company_id
-
-        self._session.add(name)
-        self._session.commit()
-        # noinspection PyTypeChecker
-        self._name_id: int = name.ID
-
-        known_udf_names: Sequence[UdfName] = self._session.scalars(
+    def _write_user_defined_fields(self, session: Session) -> None:
+        known_udf_names: Sequence[UdfName] = session.scalars(
             select(UdfName).where(UdfName.LocGrp == self._location_group_id)
         ).all()
         udf_selection_options: dict[str, set[str]] = {}
@@ -293,16 +327,16 @@ class Person(DbModel):
             if not udf_name.ComboOnly:
                 continue
 
-            udf_selection_options[udf_name.Name] = set(self._session.scalars(
-                select(UdfSel.SelText) \
-                    .where(UdfSel.UdfNum == udf_name.UdfNum) \
+            udf_selection_options[udf_name.Name] = set(session.scalars(
+                select(UdfSel.SelText)
+                    .where(UdfSel.UdfNum == udf_name.UdfNum)
                     .where(UdfSel.LocGrp == self._location_group_id)
             ).all())
 
-        known_user_defined_fields: Sequence[UDF] = self._session.scalars(
-            select(UDF) \
-                .where(UDF.NameID == self._name_id) \
-                .where(UDF.LocGrp == self._location_group_id) \
+        known_user_defined_fields: Sequence[UDF] = session.scalars(
+            select(UDF)
+                .where(UDF.NameID == self._name_id)
+                .where(UDF.LocGrp == self._location_group_id)
                 .where(UDF.UdfNum.in_([n.UdfNum for n in known_udf_names]))
         ).all()
         id_to_udf: dict[int, UDF] = {}
@@ -336,14 +370,14 @@ class Person(DbModel):
 
                 udf.UdfText = udf_text
                 del user_defined_fields_copy[udf_name_str]
-                self._session.add(udf)
+                session.add(udf)
             elif udf_name.Required:
                 raise MissingRequiredUserDefinedField(
                     f"Required user defined field {udf_name_str} not found.",
                     udf_name_str
                 )
             elif udf.ID is not None:  # Is it even in the database?
-                self._session.delete(udf)
+                session.delete(udf)
 
         # Did we have any keys we couldn't write out?
         if len(user_defined_fields_copy) > 0:
@@ -353,6 +387,44 @@ class Person(DbModel):
                 invalid_key
             )
 
-        self._session.commit()
-        self._in_db = True
-        self._lookup_info.updated_callback(self)
+    def write(self):
+        with self._lookup_info.new_session() as session:
+            name: Optional[NAMES] = None
+            if self._name_id is not None:
+                name = session.scalar(
+                    select(NAMES)
+                    .where(NAMES.ID == self._name_id)
+                    .where(NAMES.LocGrp == self._location_group_id)
+                )
+
+            if name is None:
+                name = NAMES(
+                    LocGrp=self._location_group_id,
+                )
+
+            name.FName = self._first_name
+            name.LName = self._last_name
+            name.Company = self._company_id
+
+            session.add(name)
+            session.commit()
+            # noinspection PyTypeChecker
+            self._name_id: int = name.ID
+
+            self._write_user_defined_fields(session)
+
+            session.commit()
+            self._lookup_info.updated_callback(self)
+
+
+def _new_person(lookup_info: LookupInfo) -> Person:
+    return _Person(lookup_info)
+
+
+def _existing_person(lookup_info: LookupInfo,
+                     name_id: int,
+                     first_name: Optional[str] = None,
+                     last_name: Optional[str] = None,
+                     company_id: Optional[int] = None,
+                     user_defined_fields: Optional[dict[str, str]] = None) -> Person:
+    return _Person(lookup_info, name_id, first_name, last_name, company_id, user_defined_fields)

--- a/card_automation_server/windsx/lookup/person.py
+++ b/card_automation_server/windsx/lookup/person.py
@@ -210,7 +210,7 @@ class PersonLookup(_PersonSearchBase):
     def new(self) -> Person:
         return _new_person(self._lookup_info)
 
-    def by_id(self, name_id: int) -> Person:
+    def by_id(self, name_id: int) -> Optional[Person]:
         with self._lookup_info.new_session() as session:
             name: Optional[NAMES] = session.scalar(
                 select(NAMES)
@@ -219,7 +219,7 @@ class PersonLookup(_PersonSearchBase):
             )
 
             if name is None:
-                return _new_person(self._lookup_info)
+                return None
 
             udf_data = _load_udfs(session, self._location_group_id, [name_id])
 

--- a/card_automation_server/windsx/lookup/person.py
+++ b/card_automation_server/windsx/lookup/person.py
@@ -233,48 +233,7 @@ class PersonLookup(_PersonSearchBase):
             )
 
 
-class Person(abc.ABC):
-    @property
-    @abc.abstractmethod
-    def in_db(self) -> bool: ...
-
-    @property
-    @abc.abstractmethod
-    def id(self) -> Optional[int]: ...
-
-    @property
-    @abc.abstractmethod
-    def first_name(self) -> Optional[str]: ...
-
-    @first_name.setter
-    @abc.abstractmethod
-    def first_name(self, value: str) -> None: ...
-
-    @property
-    @abc.abstractmethod
-    def last_name(self) -> Optional[str]: ...
-
-    @last_name.setter
-    @abc.abstractmethod
-    def last_name(self, value: str) -> None: ...
-
-    @property
-    @abc.abstractmethod
-    def company_id(self) -> Optional[int]: ...
-
-    @company_id.setter
-    @abc.abstractmethod
-    def company_id(self, value: int) -> None: ...
-
-    @property
-    @abc.abstractmethod
-    def user_defined_fields(self) -> dict[str, str]: ...
-
-    @abc.abstractmethod
-    def write(self): ...
-
-
-class _Person(Person):
+class _Person:
     def __init__(self,
                  lookup_info: LookupInfo,
                  name_id: Optional[int] = None,
@@ -427,6 +386,13 @@ class _Person(Person):
 
             session.commit()
             self._lookup_info.updated_callback(self)
+
+
+class _Unused:
+    pass
+
+
+Person = Union[_Person, _Unused]
 
 
 def _new_person(lookup_info: LookupInfo) -> Person:

--- a/card_automation_server/windsx/lookup/utils.py
+++ b/card_automation_server/windsx/lookup/utils.py
@@ -25,10 +25,6 @@ class LookupInfo:
         return Session(self._acs_engine)
 
     @property
-    def acs_engine(self) -> Engine:
-        return self._acs_engine
-
-    @property
     def location_group_id(self) -> int:
         return self._location_group_id
 

--- a/card_automation_server/windsx/lookup/utils.py
+++ b/card_automation_server/windsx/lookup/utils.py
@@ -1,23 +1,9 @@
-import abc
-from typing import Optional, Callable, Any
+from typing import Callable, Any
 
 from sqlalchemy import Engine
 from sqlalchemy.orm import Session
 
 from card_automation_server.windsx.engines import AcsEngine
-
-
-class DbModel(abc.ABC):
-    def __init__(self):
-        self._in_db: Optional[bool] = None
-        self._populate_from_db()
-
-    def _populate_from_db(self):
-        pass
-
-    @property
-    def in_db(self) -> bool:
-        return self._in_db
 
 
 class LookupInfo:

--- a/card_automation_server/windsx/lookup/utils.py
+++ b/card_automation_server/windsx/lookup/utils.py
@@ -2,6 +2,7 @@ import abc
 from typing import Optional, Callable, Any
 
 from sqlalchemy import Engine
+from sqlalchemy.orm import Session
 
 from card_automation_server.windsx.engines import AcsEngine
 
@@ -11,7 +12,6 @@ class DbModel(abc.ABC):
         self._in_db: Optional[bool] = None
         self._populate_from_db()
 
-    @abc.abstractmethod
     def _populate_from_db(self):
         pass
 
@@ -34,6 +34,9 @@ class LookupInfo:
         self._acs_engine: Engine = acs_engine
         self._location_group_id = location_group_id
         self._updated_callback = updated_callback
+
+    def new_session(self) -> Session:
+        return Session(self._acs_engine)
 
     @property
     def acs_engine(self) -> Engine:

--- a/card_automation_server/workers/card_pushed_watcher.py
+++ b/card_automation_server/workers/card_pushed_watcher.py
@@ -30,7 +30,7 @@ class CardPushedWatcher(EventsWorker[_Events]):
     def __init__(self,
                  lookup_info: LookupInfo):
         self._lookup_info = lookup_info
-        self._acs_session = Session(self._lookup_info.acs_engine)
+        self._acs_session = self._lookup_info.new_session()
         self._loc_cards: dict[int, LocCardInfo] = {}
         self._card_ids_to_location_updates: dict[int, set[int]] = {}
 

--- a/card_automation_server/workers/card_pushed_watcher.py
+++ b/card_automation_server/workers/card_pushed_watcher.py
@@ -96,14 +96,11 @@ class CardPushedWatcher(EventsWorker[_Events]):
             if len(locations) > 0:
                 continue  # Not all locations have been updated yet
 
-            self.outbound_queue.put(
-                AccessCardPushed(
-                    AccessCardLookup(self._lookup_info).by_id(card_id)
-                )
-            )
-
-            # Now that all locations have been updated, it's safe to remove this so we don't double notify
+            card = AccessCardLookup(self._lookup_info).by_id(card_id)
             del self._card_ids_to_location_updates[card_id]
+
+            if card is not None:
+                self.outbound_queue.put(AccessCardPushed(card))
 
     def _bring_in_new_cards(self):
         pending_loc_cards = self._acs_session.scalars(

--- a/card_automation_server/workers/card_pushed_watcher.py
+++ b/card_automation_server/workers/card_pushed_watcher.py
@@ -5,7 +5,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from card_automation_server.windsx.db.models import LocCards, LOC
-from card_automation_server.windsx.lookup.access_card import AccessCard
+from card_automation_server.windsx.lookup.access_card import AccessCardLookup
 from card_automation_server.windsx.lookup.utils import LookupInfo
 from card_automation_server.workers.events import AcsDatabaseUpdated, AccessCardUpdated, AccessCardPushed, \
     LocCardUpdated
@@ -98,7 +98,7 @@ class CardPushedWatcher(EventsWorker[_Events]):
 
             self.outbound_queue.put(
                 AccessCardPushed(
-                    AccessCard(self._lookup_info, card_id)
+                    AccessCardLookup(self._lookup_info).by_id(card_id)
                 )
             )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -405,6 +405,10 @@ def table_location_cards(session: Session):
         # 902 is used in test_updated_to_bad_location_are_ignored
     ])
 
+def pytest_configure(config: pytest.Config):
+    config.addinivalue_line(
+        "markers", "long: marks tests as a test that takes a while to run"
+    )
 
 @pytest.fixture
 def db_is_file(tmp_path: Path) -> Path:
@@ -520,6 +524,7 @@ def acs_updated_callback() -> Mock:
 
 @pytest.fixture
 def lookup_info(acs_data_engine: Engine, acs_updated_callback: Mock) -> LookupInfo:
+    # noinspection PyTypeChecker
     return LookupInfo(
         acs_engine=acs_data_engine,
         location_group_id=location_group_id,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ from card_automation_server.plugins.interfaces import Plugin
 from card_automation_server.windsx.db.engine_factory import EngineFactory
 from card_automation_server.windsx.db.models import *
 from card_automation_server.windsx.engines import AcsEngine, LogEngine
-from card_automation_server.windsx.lookup.access_card import AccessCardLookup, AccessCard
+from card_automation_server.windsx.lookup.access_card import AccessCardLookup, AccessCard, ACTIVE_STOP_DATE
 from card_automation_server.windsx.lookup.acl_group_combo import AclGroupComboLookup
 from card_automation_server.windsx.lookup.person import PersonLookup
 from card_automation_server.windsx.lookup.utils import LookupInfo
@@ -335,7 +335,7 @@ def table_cards(session: Session):
     active_card = {
         'Status': True,
         'StartDate': datetime(year=2000, month=1, day=1),
-        'StopDate': AccessCard.active_stop_date,
+        'StopDate': ACTIVE_STOP_DATE,
     }
     inactive_card = {
         'Status': False,

--- a/tests/windsx/lookup/test_access_card.py
+++ b/tests/windsx/lookup/test_access_card.py
@@ -83,7 +83,6 @@ class TestAccessCardLookup:
         assert access_card.card_number == 3000
         assert access_card.active
         assert access_card.access == frozenset({_acl_name_master_access_level})
-        assert isinstance(access_card.person, Person)
         assert access_card.person.id == 101
 
     def test_can_lookup_card_by_card_number_string(self,
@@ -95,7 +94,6 @@ class TestAccessCardLookup:
         assert access_card.card_number == 3000
         assert access_card.active
         assert access_card.access == frozenset({_acl_name_master_access_level})
-        assert isinstance(access_card.person, Person)
         assert access_card.person.id == 101
 
     def test_lookup_strips_leading_zeros(self,
@@ -107,7 +105,6 @@ class TestAccessCardLookup:
         assert access_card.card_number == 200
         assert access_card.active
         assert access_card.access == frozenset({_acl_name_master_access_level})
-        assert isinstance(access_card.person, Person)
         assert access_card.person.id == 110
 
     def test_lookup_missing_card(self,
@@ -119,8 +116,7 @@ class TestAccessCardLookup:
         assert access_card.card_number == 10000
         assert not access_card.active
         assert access_card.access == frozenset()
-        assert isinstance(access_card.person, Person)
-        assert access_card.person.id == 0
+        assert access_card.person.id is None
         assert not access_card.person.in_db
 
     def test_lookup_bad_location_group(self,
@@ -132,8 +128,7 @@ class TestAccessCardLookup:
         assert access_card.id == 0
         assert access_card.card_number == 3001
         assert not access_card.active
-        assert isinstance(access_card.person, Person)
-        assert access_card.person.id == 0
+        assert access_card.person.id is None
         assert not access_card.person.in_db
 
     def test_direct_access_bad_location_group(self, lookup_info: LookupInfo):
@@ -144,8 +139,7 @@ class TestAccessCardLookup:
         assert access_card.id == 1002
         assert access_card.card_number is None  # We never set it, so it should remain None
         assert not access_card.active
-        assert isinstance(access_card.person, Person)
-        assert access_card.person.id == 0
+        assert access_card.person.id is None
         assert not access_card.person.in_db
 
 

--- a/tests/windsx/lookup/test_access_card.py
+++ b/tests/windsx/lookup/test_access_card.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Session, InstrumentedAttribute, Mapped
 
 from card_automation_server.windsx.db.models import CARDS, DGRP, ACL, LocCards, LOC
 from card_automation_server.windsx.lookup.access_card import AccessCardLookup, AccessCard, InvalidPersonForAccessCard, \
-    LocCardUpdate
+    LocCardUpdate, ACTIVE_STOP_DATE
 from card_automation_server.windsx.lookup.person import Person, PersonLookup
 from card_automation_server.windsx.lookup.utils import LookupInfo
 from tests.conftest import main_location_id, annex_location_id
@@ -289,7 +289,7 @@ class TestAccessCardWrite:
         card: CARDS = db_helper.card_by_id(access_card.id)
         assert card.Status
         assert card.StartDate < self.today  # We don't care what it is, just that it's earlier than today
-        assert card.StopDate == AccessCard.active_stop_date
+        assert card.StopDate == ACTIVE_STOP_DATE
 
     def test_rewriting_with_existing_access_level_sets_stop_date_to_forever(self,
                                                                             acs_updated_callback: Mock,
@@ -313,7 +313,7 @@ class TestAccessCardWrite:
         card: CARDS = db_helper.card_by_id(access_card.id)
         assert card.Status
         assert card.StartDate < self.today  # We don't care what it is, just that it's earlier than today
-        assert card.StopDate == AccessCard.active_stop_date
+        assert card.StopDate == ACTIVE_STOP_DATE
 
     def test_deactivating_a_card_sets_stop_date_to_today(self,
                                                          acs_updated_callback: Mock,

--- a/tests/windsx/lookup/test_access_card.py
+++ b/tests/windsx/lookup/test_access_card.py
@@ -27,7 +27,7 @@ class DbHelper:
     @property
     def _session(self) -> Session:
         # Using a property and a new session means we avoid caching issues in the test
-        return Session(self._lookup_info.acs_engine)
+        return self._lookup_info.new_session()
 
     def card_by_id(self, card_id: int) -> Optional[CARDS]:
         return self._session.scalar(
@@ -133,6 +133,9 @@ class TestAccessCardLookup:
         assert not access_card.in_db
         assert access_card.id is None
         assert access_card.card_number == 9999
+        assert not access_card.active
+        assert access_card.access == frozenset()
+        assert access_card.person is None
 
     def test_can_lookup_card_by_id(self,
                                    access_card_lookup: AccessCardLookup):
@@ -710,6 +713,7 @@ class TestAccessCardWrite:
                                              access_card_lookup: AccessCardLookup):
         access_card: AccessCard = access_card_lookup.new(9999)
         assert not access_card.in_db
+        assert access_card.person is None
 
         with pytest.raises(InvalidPersonForAccessCard):
             access_card.write()

--- a/tests/windsx/lookup/test_access_card.py
+++ b/tests/windsx/lookup/test_access_card.py
@@ -132,6 +132,32 @@ class TestAccessCardLookup:
         assert access_card.person.id is None
         assert not access_card.person.in_db
 
+    def test_can_lookup_card_by_id(self,
+                                   access_card_lookup: AccessCardLookup):
+        access_card: AccessCard = access_card_lookup.by_id(1)
+
+        assert access_card.in_db
+        assert access_card.id == 1
+        assert access_card.card_number == 3000
+        assert access_card.active
+        assert access_card.access == frozenset({_acl_name_master_access_level})
+        assert access_card.person.id == 101
+
+    def test_lookup_by_id_that_does_not_exist(self,
+                                               access_card_lookup: AccessCardLookup):
+        access_card: AccessCard = access_card_lookup.by_id(99999)
+
+        assert not access_card.in_db
+        assert access_card.id is None
+
+    def test_lookup_by_id_in_wrong_location_group(self,
+                                                   access_card_lookup: AccessCardLookup):
+        access_card: AccessCard = access_card_lookup.by_id(1001)
+
+        # Card 1001 exists but belongs to bad_location_group, so we treat it as not found
+        assert not access_card.in_db
+        assert access_card.id is None
+
 
 class TestAccessCardWrite:
     today = datetime.combine(date.today(), datetime.min.time())

--- a/tests/windsx/lookup/test_access_card.py
+++ b/tests/windsx/lookup/test_access_card.py
@@ -110,27 +110,29 @@ class TestAccessCardLookup:
 
     def test_lookup_missing_card(self,
                                  access_card_lookup: AccessCardLookup):
-        access_card: AccessCard = access_card_lookup.by_card_number(10000)
-
-        assert not access_card.in_db
-        assert access_card.id is None
-        assert access_card.card_number == 10000
-        assert not access_card.active
-        assert access_card.access == frozenset()
-        assert access_card.person.id is None
-        assert not access_card.person.in_db
+        assert access_card_lookup.by_card_number(10000) is None
 
     def test_lookup_bad_location_group(self,
                                        access_card_lookup: AccessCardLookup):
-        access_card: AccessCard = access_card_lookup.by_card_number(3001)
-
         # This does exist in the DB, but only in an incorrect location group, so we treat it like it's not in the DB.
+        assert access_card_lookup.by_card_number(3001) is None
+
+    def test_new_card(self, access_card_lookup: AccessCardLookup):
+        access_card: AccessCard = access_card_lookup.new()
+
         assert not access_card.in_db
         assert access_card.id is None
-        assert access_card.card_number == 3001
+        assert access_card.card_number is None
         assert not access_card.active
-        assert access_card.person.id is None
-        assert not access_card.person.in_db
+        assert access_card.access == frozenset()
+        assert access_card.person is None
+
+    def test_new_card_with_card_number(self, access_card_lookup: AccessCardLookup):
+        access_card: AccessCard = access_card_lookup.new(9999)
+
+        assert not access_card.in_db
+        assert access_card.id is None
+        assert access_card.card_number == 9999
 
     def test_can_lookup_card_by_id(self,
                                    access_card_lookup: AccessCardLookup):
@@ -145,18 +147,12 @@ class TestAccessCardLookup:
 
     def test_lookup_by_id_that_does_not_exist(self,
                                                access_card_lookup: AccessCardLookup):
-        access_card: AccessCard = access_card_lookup.by_id(99999)
-
-        assert not access_card.in_db
-        assert access_card.id is None
+        assert access_card_lookup.by_id(99999) is None
 
     def test_lookup_by_id_in_wrong_location_group(self,
                                                    access_card_lookup: AccessCardLookup):
-        access_card: AccessCard = access_card_lookup.by_id(1001)
-
         # Card 1001 exists but belongs to bad_location_group, so we treat it as not found
-        assert not access_card.in_db
-        assert access_card.id is None
+        assert access_card_lookup.by_id(1001) is None
 
 
 class TestAccessCardWrite:
@@ -697,7 +693,7 @@ class TestAccessCardWrite:
                               acs_updated_callback: Mock,
                               access_card_lookup: AccessCardLookup,
                               person_lookup: PersonLookup):
-        access_card: AccessCard = access_card_lookup.by_card_number(9999)
+        access_card: AccessCard = access_card_lookup.new(9999)
         assert not access_card.in_db
 
         person: Person = person_lookup.by_name("JaneThe", "BuildingManager").find()[0]
@@ -712,7 +708,7 @@ class TestAccessCardWrite:
 
     def test_writing_new_card_with_no_person(self,
                                              access_card_lookup: AccessCardLookup):
-        access_card: AccessCard = access_card_lookup.by_card_number(9999)
+        access_card: AccessCard = access_card_lookup.new(9999)
         assert not access_card.in_db
 
         with pytest.raises(InvalidPersonForAccessCard):
@@ -720,7 +716,7 @@ class TestAccessCardWrite:
 
     def test_writing_missing_person(self,
                                     access_card_lookup: AccessCardLookup):
-        access_card: AccessCard = access_card_lookup.by_card_number(9999)
+        access_card: AccessCard = access_card_lookup.new(9999)
         assert not access_card.in_db
 
         access_card.person = 5555  # This ID doesn't exist
@@ -730,7 +726,7 @@ class TestAccessCardWrite:
 
     def test_writing_missing_person_with_different_location_group(self,
                                                                   access_card_lookup: AccessCardLookup):
-        access_card: AccessCard = access_card_lookup.by_card_number(9999)
+        access_card: AccessCard = access_card_lookup.new(9999)
         assert not access_card.in_db
 
         access_card.person = 1101  # BobThe BuildingManager with bad location group

--- a/tests/windsx/lookup/test_access_card.py
+++ b/tests/windsx/lookup/test_access_card.py
@@ -7,7 +7,8 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session, InstrumentedAttribute, Mapped
 
 from card_automation_server.windsx.db.models import CARDS, DGRP, ACL, LocCards, LOC
-from card_automation_server.windsx.lookup.access_card import AccessCardLookup, AccessCard, InvalidPersonForAccessCard
+from card_automation_server.windsx.lookup.access_card import AccessCardLookup, AccessCard, InvalidPersonForAccessCard, \
+    LocCardUpdate
 from card_automation_server.windsx.lookup.person import Person, PersonLookup
 from card_automation_server.windsx.lookup.utils import LookupInfo
 from tests.conftest import main_location_id, annex_location_id
@@ -112,7 +113,7 @@ class TestAccessCardLookup:
         access_card: AccessCard = access_card_lookup.by_card_number(10000)
 
         assert not access_card.in_db
-        assert access_card.id == 0
+        assert access_card.id is None
         assert access_card.card_number == 10000
         assert not access_card.active
         assert access_card.access == frozenset()
@@ -125,19 +126,8 @@ class TestAccessCardLookup:
 
         # This does exist in the DB, but only in an incorrect location group, so we treat it like it's not in the DB.
         assert not access_card.in_db
-        assert access_card.id == 0
+        assert access_card.id is None
         assert access_card.card_number == 3001
-        assert not access_card.active
-        assert access_card.person.id is None
-        assert not access_card.person.in_db
-
-    def test_direct_access_bad_location_group(self, lookup_info: LookupInfo):
-        access_card: AccessCard = AccessCard(lookup_info, 1002)  # Card # 3001, bad location group
-
-        # This does exist in the DB, but only in an incorrect location group, so we treat it like it's not in the DB.
-        assert not access_card.in_db
-        assert access_card.id == 1002
-        assert access_card.card_number is None  # We never set it, so it should remain None
         assert not access_card.active
         assert access_card.person.id is None
         assert not access_card.person.in_db
@@ -498,17 +488,17 @@ class TestAccessCardWrite:
         acs_updated_callback.assert_called_with(access_card)
         loc_cards = [x.args[0]
                            for x in acs_updated_callback.call_args_list
-                           if len(x.args) == 1 and isinstance(x.args[0], LocCards)]
+                           if len(x.args) == 1 and isinstance(x.args[0], LocCardUpdate)]
         assert len(loc_cards) == 2
 
         # We only care about the new, non-main one
-        expected_loc_cards = [x for x in loc_cards if x.ID != main_loc_cards.ID]
+        expected_loc_cards = [x for x in loc_cards if x.id != main_loc_cards.ID]
         assert len(expected_loc_cards) == 1
 
-        loc_cards_arg: LocCards = expected_loc_cards[0]
-        assert loc_cards_arg.ID == new_loc_cards.ID
-        assert loc_cards_arg.CardID == new_loc_cards.CardID
-        assert loc_cards_arg.Loc == new_loc_cards.Loc
+        loc_cards_arg: LocCardUpdate = expected_loc_cards[0]
+        assert loc_cards_arg.id == new_loc_cards.ID
+        assert loc_cards_arg.card_id == new_loc_cards.CardID
+        assert loc_cards_arg.loc == new_loc_cards.Loc
 
     def test_removing_card_access_sets_loc_cards_row_for_deletion(self,
                                                                   acs_data_session: Session,
@@ -545,12 +535,12 @@ class TestAccessCardWrite:
         acs_updated_callback.assert_called_with(access_card)
         loc_cards_calls = [x
                            for x in acs_updated_callback.call_args_list
-                           if len(x.args) == 1 and isinstance(x.args[0], LocCards)]
+                           if len(x.args) == 1 and isinstance(x.args[0], LocCardUpdate)]
         assert len(loc_cards_calls) == 1
-        loc_cards_arg: LocCards = loc_cards_calls[0].args[0]
-        assert loc_cards_arg.ID == loc_cards.ID
-        assert loc_cards_arg.CardID == loc_cards.CardID
-        assert loc_cards_arg.Loc == loc_cards.Loc
+        loc_cards_arg: LocCardUpdate = loc_cards_calls[0].args[0]
+        assert loc_cards_arg.id == loc_cards.ID
+        assert loc_cards_arg.card_id == loc_cards.CardID
+        assert loc_cards_arg.loc == loc_cards.Loc
 
     def test_giving_master_access_level_sets_acl_to_zero(self,
                                                          acs_data_session: Session,
@@ -605,14 +595,14 @@ class TestAccessCardWrite:
             loc_cards_calls = [
                 x for x in acs_updated_callback.call_args_list
                 if len(x.args) == 1 \
-                   and isinstance(x.args[0], LocCards) \
-                   and x.args[0].ID == loc_cards.ID
+                   and isinstance(x.args[0], LocCardUpdate) \
+                   and x.args[0].id == loc_cards.ID
             ]
             assert len(loc_cards_calls) == 1
-            loc_cards_arg: LocCards = loc_cards_calls[0].args[0]
-            assert loc_cards_arg.ID == loc_cards.ID
-            assert loc_cards_arg.CardID == loc_cards.CardID
-            assert loc_cards_arg.Loc == loc_cards.Loc
+            loc_cards_arg: LocCardUpdate = loc_cards_calls[0].args[0]
+            assert loc_cards_arg.id == loc_cards.ID
+            assert loc_cards_arg.card_id == loc_cards.CardID
+            assert loc_cards_arg.loc == loc_cards.Loc
 
     def test_rewriting_with_existing_access_level_sets_locs_cards(self,
                                                                   acs_updated_callback: Mock,
@@ -635,11 +625,11 @@ class TestAccessCardWrite:
         assert card.Status
         loc_cards_calls = [x
                            for x in acs_updated_callback.call_args_list
-                           if len(x.args) == 1 and isinstance(x.args[0], LocCards)]
+                           if len(x.args) == 1 and isinstance(x.args[0], LocCardUpdate)]
         assert len(loc_cards_calls) == 1
-        loc_cards_arg: LocCards = loc_cards_calls[0].args[0]
-        assert loc_cards_arg.CardID == card.ID
-        assert loc_cards_arg.DlFlag == 1
+        loc_cards_arg: LocCardUpdate = loc_cards_calls[0].args[0]
+        assert loc_cards_arg.card_id == card.ID
+        assert loc_cards_arg.dl_flag == 1
 
     def test_writing_card_updates_location_table_to_download(self,
                                                              db_helper: DbHelper,

--- a/tests/windsx/lookup/test_acl_group_combo.py
+++ b/tests/windsx/lookup/test_acl_group_combo.py
@@ -22,7 +22,7 @@ _bad_location_group_name = "Bad Location Group Name"
 class TestAclGroupComboLookup:
     def test_empty(self, acl_group_combo_lookup: AclGroupComboLookup):
         acl_group_combo: AclGroupComboSet = acl_group_combo_lookup.empty()
-        assert acl_group_combo.id == 0
+        assert acl_group_combo.id is None
         assert acl_group_combo.names == frozenset()
         assert not acl_group_combo.in_db
 
@@ -34,7 +34,7 @@ class TestAclGroupComboLookup:
 
     def test_lookup_by_id_that_does_not_exist(self, acl_group_combo_lookup: AclGroupComboLookup):
         acl_group_combo: AclGroupComboSet = acl_group_combo_lookup.by_id(99)
-        assert acl_group_combo.id == 99
+        assert acl_group_combo.id is None
         assert len(acl_group_combo.names) == 0
         assert not acl_group_combo.in_db
 
@@ -60,7 +60,7 @@ class TestAclGroupComboLookup:
 
     def test_lookup_by_name_with_group_that_does_not_exist(self, acl_group_combo_lookup: AclGroupComboLookup):
         acl_group_combo: AclGroupComboSet = acl_group_combo_lookup.by_names(_tenant_1, _tenant_2)
-        assert acl_group_combo.id == 0
+        assert acl_group_combo.id is None
         assert acl_group_combo.names == frozenset({_tenant_1, _tenant_2})
         assert not acl_group_combo.in_db
 
@@ -88,7 +88,7 @@ class TestAclGroupComboLookup:
 
         new_acl_group_combo: AclGroupComboSet = acl_group_combo.without_names(_main_building_access)
 
-        assert new_acl_group_combo.id == 0
+        assert new_acl_group_combo.id is None
         assert new_acl_group_combo.names == frozenset()
         assert not new_acl_group_combo.in_db
 
@@ -133,7 +133,7 @@ class TestAclGroupComboLookup:
                                                      acl_group_combo_lookup: AclGroupComboLookup):
         acl_group_combo: AclGroupComboSet = acl_group_combo_lookup.by_id(200)
 
-        assert acl_group_combo.id == 200
+        assert acl_group_combo.id is None
         assert len(acl_group_combo.names) == 0
         assert not acl_group_combo.in_db
 
@@ -143,7 +143,7 @@ class TestAclGroupComboLookup:
 
         # We should find the combo, and it should be in the database, but no names should be attached. Since only one
         # (invalid) name row is returned, as far as anyone is concerned this combo id isn't in the database.
-        assert acl_group_combo.id == 201
+        assert acl_group_combo.id is None
         assert len(acl_group_combo.names) == 0
         assert not acl_group_combo.in_db
 
@@ -165,7 +165,7 @@ class TestAclGroupComboLookup:
         acl_group_combo: AclGroupComboSet = acl_group_combo_lookup.by_names(_tenant_1, _tenant_2, _tenant_3)
 
         # Combo ID 202 does exist, but shouldn't be selected because it's a different location group.
-        assert acl_group_combo.id == 0
+        assert acl_group_combo.id is None
         assert acl_group_combo.names == frozenset({_tenant_1, _tenant_2, _tenant_3})
         assert not acl_group_combo.in_db
 

--- a/tests/windsx/lookup/test_acl_group_combo.py
+++ b/tests/windsx/lookup/test_acl_group_combo.py
@@ -33,10 +33,7 @@ class TestAclGroupComboLookup:
         assert acl_group_combo.in_db
 
     def test_lookup_by_id_that_does_not_exist(self, acl_group_combo_lookup: AclGroupComboLookup):
-        acl_group_combo: AclGroupComboSet = acl_group_combo_lookup.by_id(99)
-        assert acl_group_combo.id is None
-        assert len(acl_group_combo.names) == 0
-        assert not acl_group_combo.in_db
+        assert acl_group_combo_lookup.by_id(99) is None
 
     def test_lookup_by_name(self, acl_group_combo_lookup: AclGroupComboLookup):
         acl_group_combo: AclGroupComboSet = acl_group_combo_lookup.by_names(_tenant_1)
@@ -131,21 +128,11 @@ class TestAclGroupComboLookup:
 
     def test_by_id_that_is_in_another_location_group(self,
                                                      acl_group_combo_lookup: AclGroupComboLookup):
-        acl_group_combo: AclGroupComboSet = acl_group_combo_lookup.by_id(200)
-
-        assert acl_group_combo.id is None
-        assert len(acl_group_combo.names) == 0
-        assert not acl_group_combo.in_db
+        assert acl_group_combo_lookup.by_id(200) is None
 
     def test_by_id_where_name_is_in_another_location_group(self,
                                                            acl_group_combo_lookup: AclGroupComboLookup):
-        acl_group_combo: AclGroupComboSet = acl_group_combo_lookup.by_id(201)
-
-        # We should find the combo, and it should be in the database, but no names should be attached. Since only one
-        # (invalid) name row is returned, as far as anyone is concerned this combo id isn't in the database.
-        assert acl_group_combo.id is None
-        assert len(acl_group_combo.names) == 0
-        assert not acl_group_combo.in_db
+        assert acl_group_combo_lookup.by_id(201) is None
 
     def test_by_name_that_is_an_invalid_group_name(self, acl_group_combo_lookup: AclGroupComboLookup):
         with pytest.raises(AclGroupNameNotInDatabase) as ex:

--- a/tests/windsx/lookup/test_door_lookup.py
+++ b/tests/windsx/lookup/test_door_lookup.py
@@ -37,7 +37,6 @@ class TestDoorLookup:
         door: Door = door_lookup.by_id(1)
 
         assert door is not None
-        assert door.in_db
         assert door.id == 1
         assert door.name == 'Tenant 1 Door'
         assert door.location_id == main_location_id
@@ -63,7 +62,6 @@ class TestDoorLookup:
         door: Door = door_lookup.by_device_info(annex_location_id, 2)
 
         assert door is not None
-        assert door.in_db
         assert door.id == 7
         assert door.name == 'Tenant 3 Secret Lab Door'
         assert door.location_id == annex_location_id

--- a/tests/windsx/lookup/test_person.py
+++ b/tests/windsx/lookup/test_person.py
@@ -2,13 +2,13 @@ import re
 from unittest.mock import Mock
 
 import pytest
-from sqlalchemy import Engine, select
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from card_automation_server.windsx.db.models import UdfName
-from card_automation_server.windsx.lookup.person import PersonLookup, Person, InvalidUdfName, MissingRequiredUserDefinedField, \
+from card_automation_server.windsx.lookup.person import PersonLookup, Person, InvalidUdfName, \
+    MissingRequiredUserDefinedField, \
     InvalidUdfSelection
-from card_automation_server.windsx.lookup.utils import LookupInfo
 from tests.conftest import location_group_id
 
 

--- a/tests/windsx/lookup/test_person.py
+++ b/tests/windsx/lookup/test_person.py
@@ -138,11 +138,11 @@ class TestPersonLookup:
         person = people[0]
         self._assert_ray_securitay(person)
 
-    def test_lookup_by_invalid_id(self, lookup_info: LookupInfo):
-        person = Person(lookup_info, 5555)
+    def test_lookup_by_invalid_id(self, person_lookup: PersonLookup):
+        person = person_lookup.by_id(5555)
 
         assert not person.in_db
-        assert person.id == 5555
+        assert person.id is None
         assert person.first_name is None
         assert person.last_name is None
         assert person.company_id is None

--- a/tests/windsx/lookup/test_person.py
+++ b/tests/windsx/lookup/test_person.py
@@ -139,13 +139,7 @@ class TestPersonLookup:
         self._assert_ray_securitay(person)
 
     def test_lookup_by_invalid_id(self, person_lookup: PersonLookup):
-        person = person_lookup.by_id(5555)
-
-        assert not person.in_db
-        assert person.id is None
-        assert person.first_name is None
-        assert person.last_name is None
-        assert person.company_id is None
+        assert person_lookup.by_id(5555) is None
 
     def test_lookup_on_invalid_udf_name(self, person_lookup: PersonLookup):
         with pytest.raises(InvalidUdfName) as ex:

--- a/tests/workers/test_card_pushed_watcher.py
+++ b/tests/workers/test_card_pushed_watcher.py
@@ -5,7 +5,7 @@ from sqlalchemy import select, Engine
 from sqlalchemy.orm import Session
 
 from card_automation_server.windsx.db.models import LocCards
-from card_automation_server.windsx.lookup.access_card import AccessCard
+from card_automation_server.windsx.lookup.access_card import AccessCard, AccessCardLookup
 from card_automation_server.windsx.lookup.utils import LookupInfo
 from card_automation_server.workers.card_pushed_watcher import CardPushedWatcher
 from card_automation_server.workers.events import AcsDatabaseUpdated, AccessCardUpdated, AccessCardPushed, \
@@ -62,7 +62,7 @@ class TestCardPushedWatcher:
                                                                 acs_data_session: Session,
                                                                 card_pushed_watcher: CardPushedWatcher,
                                                                 outbound_event_queue_empty: EmptyCallable):
-        access_card = AccessCard(lookup_info, 5)
+        access_card = AccessCardLookup(lookup_info).by_card_number(2002)
         card_pushed_watcher.event(AccessCardUpdated(access_card))
 
         assert outbound_event_queue_empty()
@@ -110,7 +110,7 @@ class TestCardPushedWatcher:
                                acs_data_session: Session,
                                card_pushed_watcher: CardPushedWatcher,
                                outbound_event_queue_empty: EmptyCallable):
-        access_card = AccessCard(lookup_info, 5)
+        access_card = AccessCardLookup(lookup_info).by_card_number(2002)
         card_pushed_watcher.event(AccessCardUpdated(access_card))
 
         assert outbound_event_queue_empty()


### PR DESCRIPTION
I originally wanted to just fix the N+1 queries to see if that would help, but I realized the sessions weren't closing well which I'm pretty sure is the reason we're getting so many ODBC connection issues. The two tasks ended up going somewhat hand in hand as moving the sessions out of the db models was required to remove the N+1 queries. But that also meant it made more sense to use context managers on the sessions. And then I also realized how much I hated that queries returned a fake object so I made them return None and updated all of that as well. Not great separation as far as PRs go, but I'm also reviewing this so..... I'll probably get over it.